### PR TITLE
그래프 추가 및 데스크톱, 모바일 별 구역 구분

### DIFF
--- a/flask_sever/.idea/.gitignore
+++ b/flask_sever/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/flask_sever/.idea/flask_sever.iml
+++ b/flask_sever/.idea/flask_sever.iml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="Flask">
+    <option name="enabled" value="true" />
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Jinja2" />
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/../flask_sever\templates" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/flask_sever/.idea/inspectionProfiles/profiles_settings.xml
+++ b/flask_sever/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/flask_sever/.idea/misc.xml
+++ b/flask_sever/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (GVCS)" project-jdk-type="Python SDK" />
+</project>

--- a/flask_sever/.idea/modules.xml
+++ b/flask_sever/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/flask_sever.iml" filepath="$PROJECT_DIR$/.idea/flask_sever.iml" />
+    </modules>
+  </component>
+</project>

--- a/flask_sever/.idea/vcs.xml
+++ b/flask_sever/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/flask_sever/app.py
+++ b/flask_sever/app.py
@@ -2,10 +2,15 @@ from flask import Flask
 from dash import Dash, dcc, html
 import pandas as pd
 import plotly.express as px
+import dash_bootstrap_components as dbc
 
 server = Flask(__name__)
 app = Dash(__name__,
-           server=server,)
+           external_stylesheets=[dbc.themes.BOOTSTRAP],
+           server=server,
+           meta_tags=[{'name': 'viewport',
+                       'content': 'width=device-width, initial-scale=1.0, maximum-scale=1.2, minimum-scale=0.5,'}]
+           )
 
 # @app.route('/')
 # def hello_world():  # put application's code here
@@ -25,16 +30,116 @@ app.layout = html.Div(children=[
         걍 잡것 씨부리기.
     '''),
 
-    dcc.Graph(
-        className="image1",
-        id='example-graph',
-        figure=fig
-    ),
-    dcc.Graph(
-        className="image2",
-        id='graph',
-        figure=fig
-    )
+    dbc.Row([
+        dbc.Col([
+            dbc.Row([
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='1',
+                        figure=fig
+                    ),
+                ], xs=6, sm=6, md=6, lg=12, xl=12),
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='2',
+                        figure=fig
+                    ),
+                ], xs=6, sm=6, md=6, lg=12, xl=12)
+            ]),
+        ], xs=12, sm=12, md=12, lg=2, xl=2),
+        dbc.Col([
+            dbc.Row([
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='3',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12),
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='4',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12)
+            ])
+        ], xs=12, sm=12, md=12, lg=2, xl=2),
+        dbc.Col([
+            dbc.Row([
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='5',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12),
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='6',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12)
+            ])
+        ], xs=12, sm=12, md=12, lg=2, xl=2),
+        dbc.Col([
+            dbc.Row([
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='7',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12),
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='8',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12)
+            ])
+        ], xs=12, sm=12, md=12, lg=2, xl=2),
+        dbc.Col([
+            dbc.Row([
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='9',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12),
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='10',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12)
+            ])
+        ], xs=12, sm=12, md=12, lg=2, xl=2),
+        dbc.Col([
+            dbc.Row([
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='11',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12),
+                dbc.Col([
+                    dcc.Graph(
+                        className="image",
+                        id='12',
+                        figure=fig
+                    ),
+                ], xs=12, sm=12, md=12, lg=12, xl=12)
+            ])
+        ], xs=12, sm=12, md=12, lg=2, xl=2),
+    ]),
 ])
 
 if __name__ == '__main__':

--- a/flask_sever/app.py
+++ b/flask_sever/app.py
@@ -1,0 +1,42 @@
+from flask import Flask
+from dash import Dash, dcc, html
+import pandas as pd
+import plotly.express as px
+
+server = Flask(__name__)
+app = Dash(__name__,
+           server=server,)
+
+# @app.route('/')
+# def hello_world():  # put application's code here
+#     return 'Hello World!'
+df = pd.DataFrame({
+    "Fruit": ["Apples", "Oranges", "Bananas", "Apples", "Oranges", "Bananas"],
+    "Amount": [4, 1, 2, 2, 4, 5],
+    "City": ["SF", "SF", "SF", "Montreal", "Montreal", "Montreal"]
+})
+
+fig = px.bar(df, x="Fruit", y="Amount", color="City", barmode="group")
+
+app.layout = html.Div(children=[
+    html.H1(children='Dash에서 h1부분'),
+
+    html.Div(children='''
+        걍 잡것 씨부리기.
+    '''),
+
+    dcc.Graph(
+        className="image1",
+        id='example-graph',
+        figure=fig
+    ),
+    dcc.Graph(
+        className="image2",
+        id='graph',
+        figure=fig
+    )
+])
+
+if __name__ == '__main__':
+    #app.run(host='127.0.0.1', port=8050, debug=True)
+    app.run_server(debug=True)

--- a/flask_sever/assets/style.css
+++ b/flask_sever/assets/style.css
@@ -1,0 +1,14 @@
+.image1{
+    height:20em;
+    margin-left:2em;
+    width:22%;
+    float:left;
+    border : 1px solid lightgrey;
+}
+.image2{
+    height:20em;
+    margin-left:5em;
+    width:22%;
+    float:left;
+    border : 1px solid lightgrey;
+}

--- a/flask_sever/assets/style.css
+++ b/flask_sever/assets/style.css
@@ -1,14 +1,6 @@
-.image1{
+.image{
     height:20em;
-    margin-left:2em;
-    width:22%;
-    float:left;
-    border : 1px solid lightgrey;
-}
-.image2{
-    height:20em;
-    margin-left:5em;
-    width:22%;
+    width:100%;
     float:left;
     border : 1px solid lightgrey;
 }


### PR DESCRIPTION
파이차트 => 데스크톱: 좌측에 세로, 모바일: 최상단에 가로 배치
나머지 그래프 => 기존 피그마 방식 적용 (모바일은 계층적 구조)


![데스크탑](https://user-images.githubusercontent.com/101799316/171678297-afb5002e-5f28-4303-a4b6-bac6be94a5b4.png)  

![모바일](https://user-images.githubusercontent.com/101799316/171678388-2a4cae8d-4f37-4db9-bebc-72e09bdc16ce.png)

